### PR TITLE
Fixing Wrong Link and Adding Blogs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Please read [`contributing guidelines`](./CONTRIBUTING.md) before submitting new
 - [Weather](#weather)
 - [Quotes](#quotes)
 - [Books](#books)
+- [Blogs](#blogs)
 
 ## Development:
 
@@ -47,5 +48,14 @@ Please read [`contributing guidelines`](./CONTRIBUTING.md) before submitting new
 | API | Description |
 | ------- | ----------- |
 | [Open Library](https://openlibrary.org/developers/api) | Books, book covers, and related data. |
+
+[⬆ back to top](#table-of-contents)
+
+## Blogs
+
+| API | Description |
+| ------- | ----------- |
+| [Medium](https://github.com/Medium/medium-api-docs) | Medium’s Publishing API makes it easy for you to create your content on Medium from anywhere you write. |
+| [Dev.to](https://developers.forem.com/api) | Use this API to fetch and publish your [Dev.to](https://dev.to) articles  |
 
 [⬆ back to top](#table-of-contents)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Please read [`contributing guidelines`](./CONTRIBUTING.md) before submitting new
 | ------- | ----------- |
 | [AccuWeather](https://developer.accuweather.com/apis) | Weather and forecast data |
 | [WeatherAPI](https://www.weatherapi.com/) | WeatherAPI.com provides access to weather and geo data via a JSON/XML restful API. |
+| [OpenWeatherMap](https://openweathermap.org/api)| Get weather data for any location on the globe immediately.|
 
 ## Quotes:
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Please read [`contributing guidelines`](./CONTRIBUTING.md) before submitting new
 | API | Description |
 | ------- | ----------- |
 | [AccuWeather](https://developer.accuweather.com/apis) | Weather and forecast data |
-| [WeatherAPI](https://developer.accuweather.com/apis) | WeatherAPI.com provides access to weather and geo data via a JSON/XML restful API. |
+| [WeatherAPI](https://www.weatherapi.com/) | WeatherAPI.com provides access to weather and geo data via a JSON/XML restful API. |
 
 ## Quotes:
 


### PR DESCRIPTION

- Fixing wrong link of [WeatherAPI](https://www.weatherapi.com/)
```diff
- [WeatherAPI](https://developer.accuweather.com/apis)
+ [WeatherAPI](https://www.weatherapi.com/) 
```
- Adding [OpenWeatherMap](https://openweathermap.org/api) API
- Adding [Medium](https://github.com/Medium/medium-api-docs) and [Dev.to](https://developers.forem.com/api) APIs in Blog Section